### PR TITLE
Fix services/keynav.nix module

### DIFF
--- a/modules/services/keynav.nix
+++ b/modules/services/keynav.nix
@@ -18,7 +18,7 @@ in {
       };
 
       Service = {
-        ExecStart = "${cfg.package}/bin/keynav";
+        ExecStart = "${pkgs.keynav}/bin/keynav";
         RestartSec = 3;
         Restart = "always";
       };


### PR DESCRIPTION
Fixes issue #1177 

### Description

When the change requested in https://github.com/rycee/home-manager/pull/1082#discussion_r392715440 was applied, the service `ExecStart` attribute was not updated to use `pkgs.keynav`.

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

No test case exist for this service.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
